### PR TITLE
Fix: Add start and stop message to `installDependencies` plugin prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "template-factory",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "An unreasonably easy way to create distributable project templates.",
 	"readme": "README.md",
 	"repository": {

--- a/src/plugins/js/prompts/index.ts
+++ b/src/plugins/js/prompts/index.ts
@@ -61,6 +61,8 @@ const installDependencies = <T>({
 					await execa({ cwd: dir })`${pm} install`;
 				}
 			},
+			startMessage: 'Installing dependencies',
+			endMessage: 'Installed dependencies',
 		},
 	};
 };


### PR DESCRIPTION
- When not selecting a package manager no install progress would be shown